### PR TITLE
Feature: adding compiled shaders options

### DIFF
--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -1,15 +1,16 @@
 <script setup>
-import SourceViewer from "./SourceViewer.vue"
-import Widgets from "./Widgets.vue"
-import useMainStore from "../stores/main"
-import { ref, computed } from "vue"
-import { storeToRefs } from "pinia"
-import { useRoute } from "vue-router"
+import SourceViewer from "./SourceViewer.vue";
+import Widgets from "./Widgets.vue";
+import useMainStore from "../stores/main";
+import { ref, computed } from "vue";
+import { storeToRefs } from "pinia";
+import { useRoute } from "vue-router";
 
 const mainStore = useMainStore();
-const { glslCode, semver, pkg, loadState, shader, kind, loadError } = storeToRefs(mainStore);
+const { glslCode, semver, pkg, loadState, shader, kind, loadError, compilation } =
+  storeToRefs(mainStore);
 
-// 
+//
 // Sync states with route
 //
 
@@ -26,12 +27,12 @@ const isLoading = computed(() => loadState.value === "pending");
 const isLoadOk = computed(() => loadState.value === "fulfilled");
 const isLoadErr = computed(() => loadState.value === "rejected");
 
-// 
-// Compute shaders list and ShaderChunk 
+//
+// Compute shaders list and ShaderChunk
 //
 
 const ShaderChunk = computed(() => pkg.value?.ShaderChunk);
-const shaders = computed(() => pkg.value ? Object.keys(pkg.value.ShaderLib) : []);
+const shaders = computed(() => (pkg.value ? Object.keys(pkg.value.ShaderLib) : []));
 
 //
 // Theming
@@ -39,7 +40,7 @@ const shaders = computed(() => pkg.value ? Object.keys(pkg.value.ShaderLib) : []
 
 const mqList = matchMedia("(prefers-color-scheme: dark)");
 const dark = ref(mqList.matches);
-mqList.addEventListener("change", ({ matches }) => dark.value = matches);
+mqList.addEventListener("change", ({ matches }) => (dark.value = matches));
 
 //
 // Folding
@@ -50,11 +51,9 @@ const onFoldAll = () => viewer.value.foldAll();
 const onUnfoldAll = () => viewer.value.unfoldAll();
 </script>
 
-
-
 <template>
   <main class="host" :class="{ dark }">
-    <Widgets class="widgets" @switch-theme="dark =!dark"/>
+    <Widgets class="widgets" @switch-theme="dark = !dark" />
     <nav>
       <ul>
         <li v-if="!isLoading">
@@ -72,6 +71,12 @@ const onUnfoldAll = () => viewer.value.unfoldAll();
           </select>
         </li>
         <li v-if="isLoadOk">
+          <select v-model="compilation" title="shader compilation">
+            <option :value="false">before compilation</option>
+            <option :value="true">after compilation</option>
+          </select>
+        </li>
+        <li v-if="isLoadOk">
           <button @click="onUnfoldAll" title="unfold all #include">unfold All</button>
           <button @click="onFoldAll" title="fold all #include">fold All</button>
         </li>
@@ -82,8 +87,6 @@ const onUnfoldAll = () => viewer.value.unfoldAll();
     <pre v-if="isLoadErr" class="msg">{{ loadError }}</pre>
   </main>
 </template>
-
-
 
 <style scoped>
 @import "../assets/AppMain.css";

--- a/src/stores/compileMaterial.js
+++ b/src/stores/compileMaterial.js
@@ -1,0 +1,77 @@
+let _renderer, _scene, _camera, _mesh, _geometry, _compiledShader, _shaderRef;
+
+const onShaderError = (kind) => (gl, _, vs, fs) => {
+  //
+  // The compiled shader result on statements that are not present before the first line of _shaderRef
+  //
+
+  let shader = gl.getShaderSource(kind === "vertex" ? vs : fs);
+  if (!shader) throw new Error("Compilation error: shader not found");
+
+  const separator = _shaderRef.match(/^(.*)$/m)[0]; // separator is the first line of _shaderRef
+  const regex = new RegExp(`([\\s\\S]*?)(?=${separator})`, "gm");
+  shader = shader.match(regex); // get all characters from the beginning to the separator
+  if (!shader) throw new Error(`Compilation error: line "${separator}" not found'`);
+
+  shader = shader[0].replace(/^[ \t]+(?=precision)/gm, ""); // additional: remove space and tab before "precision" statements
+  _shaderRef = shader + _shaderRef;
+  _shaderRef = _shaderRef.slice(0, -1); // remove the '/' at the end
+};
+
+const onBeforeCompile = (kind) => (glShader) => {
+  _shaderRef = glShader[kind] = glShader[kind] + "/"; // adding '/' at the end to provoke error
+};
+
+export const setupThree = (Three) => {
+  //
+  // Needed instances before compiling shader
+  //
+  if (!_renderer) _renderer = new Three.WebGLRenderer();
+  if (!_scene) _scene = new Three.Scene();
+  if (!_camera) _camera = new Three.PerspectiveCamera();
+  if (!_geometry) _geometry = new Three.PlaneGeometry();
+};
+
+export const compileMaterial = (Three, shader, kind) => {
+  _renderer.debug.onShaderError = onShaderError(kind);
+  _mesh = undefined;
+  _scene.clear();
+
+  console.log(Three.ShaderLib);
+
+  //
+  // Setup the material
+  //
+
+  const regex = new RegExp(`${shader}material`, "i");
+  const materialName = Object.keys(Three).find((name) => name.match(regex));
+  if (!materialName) throw new Error(`Compilation error: material name is "${materialName}"`);
+  const material = new Three[materialName]();
+  material.onBeforeCompile = onBeforeCompile(`${kind}Shader`);
+
+  //
+  // Setup the mesh
+  //
+
+  if (materialName.match(/points/i)) _mesh = new Three.Line(_geometry, material);
+  else if (materialName.match(/line/i)) _mesh = new Three.Points(_geometry, material);
+  else if (materialName.match(/sprite/i)) _mesh = new Three.Sprite(material);
+  else _mesh = new Three.Mesh(_geometry, material);
+
+  //
+  // Render
+  //
+
+  _scene.add(_camera, _mesh);
+  _renderer.render(_scene, _camera);
+
+  //
+  // Clear
+  //
+
+  material.dispose();
+  _scene.clear();
+  _mesh = undefined;
+
+  return _shaderRef;
+};

--- a/src/stores/compileMaterial.js
+++ b/src/stores/compileMaterial.js
@@ -4,13 +4,12 @@ const SEPARATOR = "ErrorSeparator";
 
 const onShaderError = (kind) => (gl, _, vs, fs) => {
   //
-  // The compiled shader result on statements that are not present before the first line of the not compiled shader
+  // The compiled shader result on statements that are not present before the first line of the chunked shader
   //
-
-  const regex = new RegExp(`([\\s\\S]*?)(?=${SEPARATOR})`, "gm");
 
   let shader = gl.getShaderSource(kind === "vertex" ? vs : fs);
   if (!shader) throw new Error("shader source not found");
+  const regex = new RegExp(`([\\s\\S]*?)(?=${SEPARATOR})`, "gm");
   shader = shader.match(regex); // get all characters from the beginning to the separator
   if (!shader) throw new Error(`line "${SEPARATOR}" not found`);
   shader = shader[0].replace(/^[ \t]+(?=precision)/gm, ""); // additional: remove space and tab before "precision" statements
@@ -18,19 +17,14 @@ const onShaderError = (kind) => (gl, _, vs, fs) => {
   _shaderRef = shader;
 };
 
-export const setupThree = (Three) => {
+const compileMaterial = (Three, shader, kind) => {
   //
-  // Needed instances before compiling shader
+  // Setup instances
   //
   if (!_renderer) _renderer = new Three.WebGLRenderer();
   if (!_scene) _scene = new Three.Scene();
   if (!_camera) _camera = new Three.PerspectiveCamera();
   if (!_geometry) _geometry = new Three.PlaneGeometry();
-};
-
-export const compileMaterial = (Three, shader, kind) => {
-  if (!_renderer || !_scene || !_camera || !_geometry)
-    throw new Error("Threejs instances not setup");
 
   //
   // Setup the material
@@ -42,7 +36,7 @@ export const compileMaterial = (Three, shader, kind) => {
   const material = new Three[materialName]();
   material.onBeforeCompile = (glShader) => {
     const type = `${kind}Shader`;
-    glShader[type] = SEPARATOR + glShader[type]; // porvoke a desired error
+    glShader[type] = SEPARATOR + glShader[type]; // provoke a desired error
   };
 
   //
@@ -72,3 +66,5 @@ export const compileMaterial = (Three, shader, kind) => {
 
   return _shaderRef;
 };
+
+export default compileMaterial;

--- a/src/stores/main.js
+++ b/src/stores/main.js
@@ -77,7 +77,7 @@ export default defineStore("main", () => {
     try {
       glslCode.value = compileMaterial(pkg.value, shader.value, kind.value);
     } catch (e) {
-      glslCode.value = "// Compiled version of this shader is not available";
+      glslCode.value = `// Compiled version of this shader is not available \n// ${e}`;
     }
   });
 

--- a/src/stores/main.js
+++ b/src/stores/main.js
@@ -69,15 +69,17 @@ export default defineStore("main", () => {
       return;
     }
 
+    const str = pkg.value.ShaderLib[shader.value][kind.value + "Shader"];
+
     if (!compilation.value) {
-      glslCode.value = pkg.value.ShaderLib[shader.value][kind.value + "Shader"];
+      glslCode.value = str;
       return;
     }
 
     try {
-      glslCode.value = compileMaterial(pkg.value, shader.value, kind.value);
+      glslCode.value = compileMaterial(pkg.value, shader.value, kind.value) + str;
     } catch (e) {
-      glslCode.value = `// Compiled version of this shader is not available \n// ${e}`;
+      glslCode.value = `// Compiled version of this shader is not available \n` + str;
     }
   });
 

--- a/src/stores/main.js
+++ b/src/stores/main.js
@@ -1,7 +1,7 @@
 import { watch, computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { defineStore } from "pinia";
-import { setupThree, compileMaterial } from "./compileMaterial";
+import compileMaterial from "./compileMaterial";
 
 export default defineStore("main", () => {
   const pkg = ref(null);
@@ -31,7 +31,6 @@ export default defineStore("main", () => {
         );
         loadState.value = "fulfilled";
         loadError.value = null;
-        setupThree(pkg.value); // setup here to improve later compilation process
       } catch (e) {
         // reset
         pkg.value = null;
@@ -69,17 +68,18 @@ export default defineStore("main", () => {
       return;
     }
 
-    const str = pkg.value.ShaderLib[shader.value][kind.value + "Shader"];
+    const chunks = pkg.value.ShaderLib[shader.value][kind.value + "Shader"];
 
     if (!compilation.value) {
-      glslCode.value = str;
+      glslCode.value = chunks;
       return;
     }
 
     try {
-      glslCode.value = compileMaterial(pkg.value, shader.value, kind.value) + str;
+      const additionnals = compileMaterial(pkg.value, shader.value, kind.value);
+      glslCode.value = additionnals + chunks;
     } catch (e) {
-      glslCode.value = `// Compiled version of this shader is not available \n` + str;
+      glslCode.value = `// Compiled version of this shader is not available \n` + chunks;
     }
   });
 


### PR DESCRIPTION
Hi,

I use the skim version of your project a lot and I wanted to contribute by adding a new feature to your code.
In my repository, I list all the compiled shaders from Three.js, but unlike your project, I don’t provide an interactive version. Here’s my [repo](https://github.com/Jonathan-J8/three-materials-compiled) for reference.

Your project inspired me to implement a similar feature, allowing users to switch between two options:
* Before Compilation
* After Compilation

The first option uses your original code, while the second compiles the shader and add the differences from the first option. Importantly, this feature doesn’t modify the source code of Three.js, making it safe to use even it its kind of a hack. 
However, certain shaders cannot compile (cube, background, equirect, etc...). In such cases, the result return a comments at its top.
For future improvements, it will be nice to find a solution for the compilation time. It can freeze the MainThread on big shaders (standard, physical, phong, ...). Maybe move all the compilation to a worker?
 
I hope you find this addition useful, and I’d love to hear your thoughts or feedback!

Best,